### PR TITLE
feat: config parser w/ KDL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.rulers": [100],
   "editor.formatOnSave": true,
-  "editor.inlayHints.enabled": "off",
+  "editor.inlayHints.enabled": "offUnlessPressed",
   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "rust-analyzer.diagnostics.disabled": ["macro-error"],
   "rust-analyzer.lens.enable": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,11 @@
 {
   "editor.rulers": [100],
   "editor.formatOnSave": true,
-  "editor.inlayHints.enabled": "offUnlessPressed",
+  "editor.inlayHints.enabled": "off",
   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "rust-analyzer.diagnostics.disabled": ["macro-error"],
-  "rust-analyzer.lens.enable": true
+  "rust-analyzer.lens.enable": true,
+  "rust-analyzer.server.extraEnv": {
+    "CHALK_OVERFLOW_DEPTH": "1000"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,5 @@
   "editor.inlayHints.enabled": "off",
   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "rust-analyzer.diagnostics.disabled": ["macro-error"],
-  "rust-analyzer.lens.enable": true,
-  "rust-analyzer.server.extraEnv": {
-    "CHALK_OVERFLOW_DEPTH": "1000"
-  }
+  "rust-analyzer.lens.enable": true
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ tar = { version = "0.4" }
 tokio = { version = "1.16", features = ["full"] }
 url = "2.2"
 kdl = "4.2"
+petgraph = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ description = "Simple CLI to help scaffold projects from templates in a touch."
 repository = "https://github.com/norskeld/imp"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = { version = "3.0", features = ["cargo", "derive"] }
 chumsky = { version = "0.8" }
@@ -17,3 +15,4 @@ reqwest = { version = "0.11", features = ["json"] }
 tar = { version = "0.4" }
 tokio = { version = "1.16", features = ["full"] }
 url = "2.2"
+kdl = "4.2"

--- a/imp.kdl
+++ b/imp.kdl
@@ -1,0 +1,31 @@
+// Static replacements
+replacements {
+  R_NAME "Repository name"
+  R_DESC "Repository description"
+  R_AUTHOR "Repository author"
+}
+
+// Actions to perform on files
+actions {
+  suite name="init" {
+    copy from="path/to/file/or/dir" to="path/to/target"
+    copy from="glob/pattern" to="path/to/target/dir"
+
+    // Can also be used to rename files or directories
+    move from="path/to/file/or/dir" to="path/to/target"
+    move from="glob/pattern" to="path/to/target/dir"
+
+    delete "path/to/file/or/dir"
+    delete "glob/pattern"
+  }
+
+  suite name="lint" requires="init" {
+    run "cargo fmt" "cargo clippy"
+  }
+
+  suite name="git" requires="init lint" {
+    run "git init"
+    run "git add ."
+    run "git commit -m 'chore: init'"
+  }
+}

--- a/imp.kdl
+++ b/imp.kdl
@@ -20,7 +20,7 @@ actions {
   }
 
   suite name="lint" requires="init" {
-    run "cargo fmt" "cargo clippy"
+    run "cargo fmt"
   }
 
   suite name="git" requires="init lint" {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,8 @@
 use kdl::{KdlDocument, KdlEntry, KdlNode};
 
+use crate::app::AppError;
+use crate::graph::{DependenciesGraph, Node, Step};
+
 #[derive(Debug)]
 pub struct Replacement {
   pub tag: String,
@@ -12,14 +15,26 @@ pub enum Action {
   Single(Vec<ActionSingle>),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ActionSuite {
   pub name: String,
   pub actions: Vec<ActionSingle>,
   pub requirements: Vec<String>,
 }
 
-#[derive(Debug)]
+impl Node for ActionSuite {
+  type Item = String;
+
+  fn dependencies(&self) -> &[Self::Item] {
+    &self.requirements[..]
+  }
+
+  fn matches(&self, dependency: &Self::Item) -> bool {
+    self.name == *dependency
+  }
+}
+
+#[derive(Clone, Debug)]
 pub enum ActionSingle {
   Copy {
     from: Option<String>,
@@ -38,6 +53,19 @@ pub enum ActionSingle {
     command: Option<String>,
   },
   Unknown,
+}
+
+pub fn resolve_requirements(suites: &[ActionSuite]) -> (Vec<ActionSuite>, Vec<String>) {
+  let graph = DependenciesGraph::from(suites);
+
+  graph.fold((vec![], vec![]), |(mut resolved, mut unresolved), next| {
+    match next {
+      | Step::Resolved(suite) => resolved.push(suite.clone()),
+      | Step::Unresolved(dep) => unresolved.push(dep.clone()),
+    }
+
+    (resolved, unresolved)
+  })
 }
 
 pub fn get_actions(doc: &KdlDocument) -> Option<Action> {
@@ -72,7 +100,7 @@ pub fn get_replacements(doc: &KdlDocument) -> Option<Vec<Replacement>> {
 
 fn to_replacement(node: &KdlNode) -> Option<Replacement> {
   let tag = node.name().to_string();
-  let description = node.get(0).map(entry_to_string);
+  let description = node.get(0).and_then(entry_to_string);
 
   Some(Replacement { tag, description })
 }
@@ -88,12 +116,12 @@ fn to_action(node: &KdlNode) -> Option<ActionSingle> {
 }
 
 fn to_action_suite(node: &KdlNode) -> Option<ActionSuite> {
-  let name = node.get("name").map(entry_to_string);
-  let requirements = node.get("requires").map(entry_to_string).map(|value| {
+  let name = node.get("name").and_then(entry_to_string);
+  let requirements = node.get("requires").and_then(entry_to_string).map(|value| {
     value
       .split_ascii_whitespace()
       .map(str::to_string)
-      .collect::<Vec<String>>()
+      .collect::<Vec<_>>()
   });
 
   let actions = node.children().map(|children| {
@@ -125,26 +153,26 @@ fn to_action_single(node: &KdlNode) -> ActionSingle {
 
   match action_kind.to_ascii_lowercase().as_str() {
     | "copy" => ActionSingle::Copy {
-      from: node.get("from").map(entry_to_string),
-      to: node.get("to").map(entry_to_string),
+      from: node.get("from").and_then(entry_to_string),
+      to: node.get("to").and_then(entry_to_string),
       overwrite: node
         .get("overwrite")
         .and_then(|value| value.value().as_bool())
         .unwrap_or(true),
     },
     | "move" => ActionSingle::Move {
-      from: node.get("from").map(entry_to_string),
-      to: node.get("to").map(entry_to_string),
+      from: node.get("from").and_then(entry_to_string),
+      to: node.get("to").and_then(entry_to_string),
       overwrite: node
         .get("overwrite")
         .and_then(|value| value.value().as_bool())
         .unwrap_or(true),
     },
     | "delete" => ActionSingle::Delete {
-      target: node.get(0).map(entry_to_string),
+      target: node.get(0).and_then(entry_to_string),
     },
     | "run" => ActionSingle::Run {
-      command: node.get(0).map(entry_to_string),
+      command: node.get(0).and_then(entry_to_string),
     },
     | _ => ActionSingle::Unknown,
   }
@@ -154,6 +182,7 @@ fn is_suite(node: &KdlNode) -> bool {
   node.name().value().to_string().eq("suite".into())
 }
 
-fn entry_to_string(entry: &KdlEntry) -> String {
-  entry.value().to_string()
+fn entry_to_string(entry: &KdlEntry) -> Option<String> {
+  // dbg!(entry.value());
+  entry.value().as_string().map(str::to_string)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,155 @@
+use kdl::{KdlDocument, KdlEntry, KdlNode};
+
+#[derive(Debug)]
+pub struct Replacement {
+  pub tag: String,
+  pub description: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum Action {
+  Suite(Vec<ActionSuite>),
+  Single(Vec<ActionSingle>),
+}
+
+#[derive(Debug)]
+pub struct ActionSuite {
+  pub name: String,
+  pub actions: Vec<ActionSingle>,
+  pub requirements: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum ActionSingle {
+  Copy {
+    from: Option<String>,
+    to: Option<String>,
+    overwrite: bool,
+  },
+  Move {
+    from: Option<String>,
+    to: Option<String>,
+    overwrite: bool,
+  },
+  Delete {
+    target: Option<String>,
+  },
+  Run {
+    command: Option<String>,
+  },
+  Unknown,
+}
+
+pub fn get_actions(doc: &KdlDocument) -> Option<Action> {
+  doc
+    .get("actions")
+    .and_then(|node| node.children())
+    .map(|children| {
+      let nodes = children.nodes();
+
+      if nodes.iter().all(is_suite) {
+        let suites = nodes.iter().filter_map(to_sequence).collect::<Vec<_>>();
+        Action::Suite(suites)
+      } else {
+        let operations = nodes.iter().filter_map(to_operation).collect::<Vec<_>>();
+        Action::Single(operations)
+      }
+    })
+}
+
+pub fn get_replacements(doc: &KdlDocument) -> Option<Vec<Replacement>> {
+  doc
+    .get("replacements")
+    .and_then(|node| node.children())
+    .map(|children| {
+      children
+        .nodes()
+        .iter()
+        .filter_map(to_replacement)
+        .collect::<Vec<_>>()
+    })
+}
+
+fn to_replacement(node: &KdlNode) -> Option<Replacement> {
+  let tag = node.name().to_string();
+  let description = node.get(0).map(entry_to_string);
+
+  Some(Replacement { tag, description })
+}
+
+fn to_operation(node: &KdlNode) -> Option<ActionSingle> {
+  let action = to_action(node);
+
+  if let ActionSingle::Unknown = action {
+    None
+  } else {
+    Some(action)
+  }
+}
+
+fn to_sequence(node: &KdlNode) -> Option<ActionSuite> {
+  let name = node.get("name").map(entry_to_string);
+  let requirements = node.get("requires").map(entry_to_string).map(|value| {
+    value
+      .split_ascii_whitespace()
+      .map(str::to_string)
+      .collect::<Vec<String>>()
+  });
+
+  let actions = node
+    .children()
+    .map(|children| children.nodes().iter().map(to_action).collect::<Vec<_>>());
+
+  let suite = (
+    name,
+    actions.unwrap_or(vec![]),
+    requirements.unwrap_or(vec![]),
+  );
+
+  match suite {
+    | (Some(name), actions, requirements) => Some(ActionSuite {
+      name,
+      actions,
+      requirements,
+    }),
+    | _ => None,
+  }
+}
+
+fn to_action(node: &KdlNode) -> ActionSingle {
+  let action_kind = node.name().to_string();
+
+  match action_kind.to_ascii_lowercase().as_str() {
+    | "copy" => ActionSingle::Copy {
+      from: node.get("from").map(entry_to_string),
+      to: node.get("to").map(entry_to_string),
+      overwrite: node
+        .get("overwrite")
+        .and_then(|value| value.value().as_bool())
+        .unwrap_or(true),
+    },
+    | "move" => ActionSingle::Move {
+      from: node.get("from").map(entry_to_string),
+      to: node.get("to").map(entry_to_string),
+      overwrite: node
+        .get("overwrite")
+        .and_then(|value| value.value().as_bool())
+        .unwrap_or(true),
+    },
+    | "delete" => ActionSingle::Delete {
+      target: node.get(0).map(entry_to_string),
+    },
+    | "run" => ActionSingle::Run {
+      command: node.get(0).map(entry_to_string),
+    },
+    | _ => ActionSingle::Unknown,
+  }
+}
+
+fn is_suite(node: &KdlNode) -> bool {
+  node.name().value().to_string().eq("suite".into())
+}
+
+fn entry_to_string(entry: &KdlEntry) -> String {
+  entry.value().to_string()
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,108 @@
+use petgraph::stable_graph::StableDiGraph;
+use petgraph::Direction;
+
+pub trait Node {
+  type Item;
+
+  fn dependencies(&self) -> &[Self::Item];
+  fn matches(&self, dep: &Self::Item) -> bool;
+}
+
+#[derive(Debug)]
+pub enum Step<'a, N: Node> {
+  Resolved(&'a N),
+  Unresolved(&'a N::Item),
+}
+
+impl<'a, N: Node> Step<'a, N> {
+  pub fn is_resolved(&self) -> bool {
+    match self {
+      | Step::Resolved(_) => true,
+      | Step::Unresolved(_) => false,
+    }
+  }
+
+  pub fn as_resolved(&self) -> Option<&N> {
+    match self {
+      | Step::Resolved(node) => Some(node),
+      | Step::Unresolved(_) => None,
+    }
+  }
+
+  pub fn as_unresolved(&self) -> Option<&N::Item> {
+    match self {
+      | Step::Resolved(_) => None,
+      | Step::Unresolved(requirement) => Some(requirement),
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct DependenciesGraph<'a, N: Node> {
+  graph: StableDiGraph<Step<'a, N>, &'a N::Item>,
+}
+
+impl<'a, N> From<&'a [N]> for DependenciesGraph<'a, N>
+where
+  N: Node,
+{
+  fn from(nodes: &'a [N]) -> Self {
+    let mut graph = StableDiGraph::<Step<'a, N>, &'a N::Item>::new();
+
+    // Insert the input nodes into the graph, and record their positions. We'll be adding the edges
+    // next, and filling in any unresolved steps we find along the way.
+    let nodes: Vec<(_, _)> = nodes
+      .iter()
+      .map(|node| (node, graph.add_node(Step::Resolved(node))))
+      .collect();
+
+    for (node, index) in nodes.iter() {
+      for dependency in node.dependencies() {
+        // Check to see if we can resolve this dependency internally.
+        if let Some((_, dependent)) = nodes.iter().find(|(dep, _)| dep.matches(dependency)) {
+          // If we can, just add an edge between the two nodes.
+          graph.add_edge(*index, *dependent, dependency);
+        } else {
+          // If not, create a new Unresolved node, and create an edge to that.
+          let unresolved = graph.add_node(Step::Unresolved(dependency));
+          graph.add_edge(*index, unresolved, dependency);
+        }
+      }
+    }
+
+    Self { graph }
+  }
+}
+
+impl<'a, N> DependenciesGraph<'a, N>
+where
+  N: Node,
+{
+  pub fn is_resolvable(&self) -> bool {
+    self.graph.node_weights().all(Step::is_resolved)
+  }
+
+  pub fn unresolved(&self) -> impl Iterator<Item = &N::Item> {
+    self.graph.node_weights().filter_map(Step::as_unresolved)
+  }
+}
+
+impl<'a, N> Iterator for DependenciesGraph<'a, N>
+where
+  N: Node,
+{
+  type Item = Step<'a, N>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    // Returns the first node, which does not have any Outgoing edges, which means it is terminal.
+    for index in self.graph.node_indices().rev() {
+      let neighbors = self.graph.neighbors_directed(index, Direction::Outgoing);
+
+      if neighbors.count() == 0 {
+        return self.graph.remove_node(index);
+      }
+    }
+
+    None
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ pub mod app;
 pub mod config;
 
 mod extract;
+mod graph;
 mod parser;
 mod repository;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
 pub mod app;
+pub mod config;
 
 mod extract;
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 
 use kdl::KdlDocument;
-use imp::config;
+use imp::config::{self, Action};
 
 // use imp::app::{self, AppError};
 
@@ -12,14 +12,21 @@ use imp::config;
 // }
 
 fn main() -> std::io::Result<()> {
-  let mut filename = env::current_dir()?;
-  filename.push("imp.kdl");
+  let filename = env::current_dir()?.join("imp.kdl");
 
   let contents = fs::read_to_string(filename)?;
   let doc: KdlDocument = contents.parse().expect("Failed to parse config file.");
 
-  println!("{:#?}", config::get_replacements(&doc));
-  println!("{:#?}", config::get_actions(&doc));
+  let actions = config::get_actions(&doc);
+
+  actions.map(|action| {
+    if let Action::Suite(suites) = action {
+      let (resolved, unresolved) = config::resolve_requirements(&suites);
+
+      println!("Resolved: {resolved:#?}");
+      println!("Unresolved: {unresolved:#?}");
+    }
+  });
 
   Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,25 @@
-use imp::app;
+use std::env;
+use std::fs;
 
-fn main() {
-  app::run()
+use kdl::KdlDocument;
+use imp::config;
+
+// use imp::app::{self, AppError};
+
+// #[tokio::main]
+// async fn main() -> Result<(), AppError> {
+//   app::run().await
+// }
+
+fn main() -> std::io::Result<()> {
+  let mut filename = env::current_dir()?;
+  filename.push("imp.kdl");
+
+  let contents = fs::read_to_string(filename)?;
+  let doc: KdlDocument = contents.parse().expect("Failed to parse config file.");
+
+  println!("{:#?}", config::get_replacements(&doc));
+  println!("{:#?}", config::get_actions(&doc));
+
+  Ok(())
 }


### PR DESCRIPTION
Provide means for parsing config file in the [KDL] format, e.g.

- [x] Parse replacements

```zig
// Static replacements
replacements {
  R_NAME "Repository name"
  R_DESC "Repository description"
  R_AUTHOR "Repository author"
}
```

- [x] Parse sequence of actions

```zig
actions {
  copy from="path/to/file/or/dir" to="path/to/target"
  move from="path/to/file/or/dir" to="path/to/target"
  delete "path/to/file/or/dir"
  run "cargo build"
}
```

- [x] Parse suites of actions

```zig
// Actions to perform on files
actions {
  suite name="init" {
    copy from="path/to/file/or/dir" to="path/to/target"
    copy from="glob/pattern" to="path/to/target/dir"

    // Can also be used to rename files or directories
    move from="path/to/file/or/dir" to="path/to/target"
    move from="glob/pattern" to="path/to/target/dir"
  }

  suite name="clean-up" {
    delete "path/to/file/or/dir"
    delete "glob/pattern"
  }

  // You can mark a suite as a dependent on other suite(s) using "requires" prop
  suite name="git" requires="init clean-up" {
    run "git init"
    run "git add ."
    run "git commit -m 'chore: init'"
  }
}
```

- [x] Dependency resolution, i.e. dependency graph for suites

<!-- Links. -->

[KDL]: https://github.com/kdl-org/kdl